### PR TITLE
fix postgres dialect name for DATABASE_URL template in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ pip install -r requirements.txt
 ```
 ### Переименовать файл .env.dev в .env и указать в нем недостающую информацию (используемую базу данных и токен бота):
 ```
-DATABASE_URL=postgres://{user}:{password}@{hostname}:{port}/{database-name}
+DATABASE_URL=postgresql://{user}:{password}@{hostname}:{port}/{database-name}
 TOKEN=<ваш токен>
 ```
 В проекте нельзя использовать базу данных SQLite. Рекомендуется PostgreSQL.


### PR DESCRIPTION
SQLAlchemy 1.4 removed the deprecated `postgres` dialect name, the name `postgresql` must be used instead now: https://stackoverflow.com/a/66794960