### PR TITLE
Some updates with feature send_task

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -51,7 +51,7 @@ PAGE_LIMIT = 10
 TELEGRAM_TOKEN = os.getenv('TOKEN')
 WEBHOOK_URL = f'{HOST_NAME}/api/{TELEGRAM_TOKEN}/telegramWebhook'
 USE_WEBHOOK = os.getenv('USE_WEBHOOK')
-NUMBER_USERS_TO_SEND = 5
+MAILING_BATCH_SIZE = 5
 
 BOT_FILE_DIR = BASE_DIR + '/bot_persistence_file/'
 BOT_PERSISTENCE_FILE = os.path.join(BOT_FILE_DIR, 'bot_persistence_data')

--- a/app/webhooks/tasks.py
+++ b/app/webhooks/tasks.py
@@ -133,11 +133,12 @@ class CreateTasks(MethodResource, Resource):
                     user_notification_context.user_message_context.append(user_message_context)
             logger.info(f"Tasks: User's mailing list - {[user_message_context.telegram_id for user_message_context in user_notification_context.user_message_context]}")
             if len(user_notification_context.user_message_context) != 0:
-                send_time = notification.send_batch_messages(user_notification_context, send_time)
+                dispatcher.job_queue.run_once(notification.send_batch_messages, send_time, context=user_notification_context,
+                                              name=f'Sending: {message[0:10]}')
 
                 logger.info(f"Tasks: submitting task: {task.id} {task.title}")
-        # Adds a 10 second delay before processing the next post
-        time.sleep(10)
+            # Adds a 10 second delay before processing the next task
+            send_time = send_time + datetime.timedelta(seconds=10)
     
     def __add_tasks(self, tasks_to_add, task_to_send):
         task_ids = [task['id'] for task in tasks_to_add]

--- a/app/webhooks/tasks.py
+++ b/app/webhooks/tasks.py
@@ -111,10 +111,10 @@ class CreateTasks(MethodResource, Resource):
                                      , 200)
 
     def preparing_tasks_for_send(self, task_to_send):
-        logger.info(f"Tasks: Tasks passed to the preparing_tasks_for_send method - {[(task.id, task.title) for task in task_to_send]}")
         if not task_to_send:
             logger.info("Tasks: No tasks to send")
             return
+        logger.info(f"Tasks: Tasks passed to the preparing_tasks_for_send method - {[(task.id, task.title) for task in task_to_send]}")
         notification = TelegramNotification()
 
         send_time = datetime.datetime.now(pytz.utc)
@@ -125,7 +125,7 @@ class CreateTasks(MethodResource, Resource):
             logger.info(f"Tasks: Users with a subscription to {category_id} category in DB - {[user.telegram_id for user in users]}")
             users_list = []
             for user in users:
-                if user.has_mailing == True:
+                if user.has_mailing:
                     users_list.append(user)
             logger.info(f"Tasks: User's mailing list - {[user.telegram_id for user in users_list]}")
             if users_list:

--- a/app/webhooks/tasks.py
+++ b/app/webhooks/tasks.py
@@ -130,7 +130,6 @@ class CreateTasks(MethodResource, Resource):
                     users_list.append(user)
             logger.info(f"Tasks: User's mailing list - {[user.telegram_id for user in users_list]}")
             if users_list:
-                send_time = send_time + datetime.timedelta(seconds=1)
                 send_time = notification.send_new_tasks(message=display_task_notification(task), send_to=users_list, send_time=send_time)
                 logger.info(f"Tasks: submitted task: {task.id} {task.title}")
     

--- a/app/webhooks/tasks.py
+++ b/app/webhooks/tasks.py
@@ -114,6 +114,7 @@ class CreateTasks(MethodResource, Resource):
         if not task_to_send:
             logger.info("Tasks: No tasks to send")
             return
+        
         logger.info(f"Tasks: Tasks passed to the preparing_tasks_for_send method - {[(task.id, task.title) for task in task_to_send]}")
         notification = TelegramNotification()
 

--- a/app/webhooks/tasks.py
+++ b/app/webhooks/tasks.py
@@ -120,6 +120,7 @@ class CreateTasks(MethodResource, Resource):
         logger.info(f"Tasks: Tasks passed to the preparing_tasks_for_send method - {[(task.id, task.title) for task in task_to_send]}")
         notification = TelegramNotification()
 
+        send_time = datetime.datetime.now(pytz.utc)
         for task in task_to_send:
             category_id = task.category_id
             users = Category.query.filter_by(id = category_id).first().users
@@ -132,7 +133,7 @@ class CreateTasks(MethodResource, Resource):
                     user_notification_context.user_message_context.append(user_message_context)
             logger.info(f"Tasks: User's mailing list - {[user_message_context.telegram_id for user_message_context in user_notification_context.user_message_context]}")
             if len(user_notification_context.user_message_context) != 0:
-                notification.send_batch_messages(user_notification_context)
+                send_time = notification.send_batch_messages(user_notification_context, send_time)
 
                 logger.info(f"Tasks: submitting task: {task.id} {task.title}")
         # Adds a 10 second delay before processing the next post

--- a/app/webhooks/tasks.py
+++ b/app/webhooks/tasks.py
@@ -110,9 +110,10 @@ class CreateTasks(MethodResource, Resource):
                                      , 200)
 
     def preparing_tasks_for_send(self, task_to_send):
-        task_ids = [task.id for task in task_to_send]
+        logger.info(f"Tasks: Tasks passed to the send_task method - {[(task.id, task.title) for task in task_to_send]}")
         if task_to_send:
             users = User.query.options(load_only('telegram_id')).filter_by(has_mailing=True).all()
+            logger.info(f"Tasks: Users with an enabled subscription in DB - {[user.telegram_id for user in users]}")
             notification = TelegramNotification()
 
             send_time = datetime.datetime.now(pytz.utc)
@@ -122,11 +123,11 @@ class CreateTasks(MethodResource, Resource):
                 for user in users:
                     if task.category_id in [cat.id for cat in user.categories]:
                         chats_list.append(user)
-
+                logger.info(f"Tasks: User's mailing list - {[user.telegram_id for user in chats_list]}")
                 if chats_list:
                     send_time = send_time + datetime.timedelta(seconds=1)
                     send_time = notification.send_new_tasks(message=display_task_notification(task), send_to=chats_list, send_time=send_time)
-        logger.info(f"Tasks: Tasks to send ids: {task_ids}")
+                    logger.info(f"Tasks: submitted task: {task.id} {task.title}")
     
     def __add_tasks(self, tasks_to_add, task_to_send):
         task_ids = [task['id'] for task in tasks_to_add]

--- a/app/webhooks/tasks.py
+++ b/app/webhooks/tasks.py
@@ -132,7 +132,7 @@ class CreateTasks(MethodResource, Resource):
             if context_list:
                 user_notification_context = SendUserNotificationsContext(context_list)
 
-                send_time = notification.SendBatchMessages(user_notification_context)
+                notification.SendBatchMessages(user_notification_context)
 
                 logger.info(f"Tasks: submitted task: {task.id} {task.title}")
         time.sleep(10)

--- a/bot/messages.py
+++ b/bot/messages.py
@@ -4,6 +4,7 @@ import datetime
 import time
 from dataclasses import dataclass
 from typing import List
+import pytz
 
 from app import config
 from app.database import db_session
@@ -59,36 +60,42 @@ class TelegramNotification:
 
         user_notification_context = SendUserNotificationsContext([])
         for user in chats_list:
-             user_message_context = SendUserMessageContext(message=message, telegram_id=user.telegram_id)
-             user_notification_context.user_message_context.append(user_message_context)
-
-        self.send_batch_messages(user_notification_context)
+            user_message_context = SendUserMessageContext(message=message, telegram_id=user.telegram_id)
+            user_notification_context.user_message_context.append(user_message_context)
+            send_time = datetime.datetime.now(pytz.utc)
+        send_time = self.send_batch_messages(user_notification_context, send_time)
 
         return True
 
-    def send_batch_messages(self, user_notification_context):
+    def send_batch_messages(self, user_notification_context, send_time):
         for send_set in self.__split_chats(user_notification_context.user_message_context, config.MAILING_BATCH_SIZE):
 
             for user_message_context in send_set:
-                self.__send_message_context(user_message_context)
-            time.sleep(1)
+                dispatcher.job_queue.run_once(self.__send_message_context, send_time, context=user_message_context,
+                                              name=f'Sending: {user_message_context.message[0:10]}')
+                send_time = send_time + datetime.timedelta(seconds=1)
+                # self.__send_message_context(user_message_context)
+        return send_time
                 
     def __send_message_context(self, user_message_context):
+        job = user_message_context.job
+        message = job.context.message
+        telegram_id = job.context.telegram_id
         tries = 3
         for i in range(tries):
             try:
-                bot.send_message(chat_id=user_message_context.telegram_id, text=user_message_context.message,
+                bot.send_message(chat_id=telegram_id, text=message,
                                 parse_mode=ParseMode.HTML, disable_web_page_preview=True)
-                logger.info(f"Sent message to {user_message_context.telegram_id}")
+                logger.info(f"Sent message to {telegram_id}")
                 return
             except error.BadRequest as ex:
-                logger.error(f'{str(ex.message)}, telegram_id: {user_message_context.telegram_id}')
+                logger.error(f'{str(ex.message)}, telegram_id: {telegram_id}')
                 if i < tries:
                     logger.info(f"Retry to send after {i}")
                     time.sleep(i)
             except Unauthorized as ex:
-                logger.error(f'{str(ex.message)}: {user_message_context.telegram_id}')
-                User.query.filter_by(telegram_id=user_message_context.telegram_id).update({'banned': True, 'has_mailing': False})
+                logger.error(f'{str(ex.message)}: {telegram_id}')
+                User.query.filter_by(telegram_id=telegram_id).update({'banned': True, 'has_mailing': False})
                 db_session.commit()
 
     @staticmethod

--- a/bot/messages.py
+++ b/bot/messages.py
@@ -57,7 +57,7 @@ class TelegramNotification:
         for chats_count, chats_set in enumerate(self.__split_chats(send_to, config.MAILING_BATCH_SIZE)):
             context = {'message': message, 'chats': chats_set}
 
-            send_time = send_time + datetime.timedelta(seconds=chats_count)
+            send_time = send_time + datetime.timedelta(seconds=chats_count+1)
 
             dispatcher.job_queue.run_once(self.__send_message, send_time, context=context,
                                           name=f'Task: {message[0:10]}_{chats_count}')

--- a/bot/messages.py
+++ b/bot/messages.py
@@ -62,8 +62,10 @@ class TelegramNotification:
         for user in chats_list:
             user_message_context = SendUserMessageContext(message=message, telegram_id=user.telegram_id)
             user_notification_context.user_message_context.append(user_message_context)
+        
+        seconds = 1
 
-        dispatcher.job_queue.run_once(self.send_batch_messages, 1, context=user_notification_context,
+        dispatcher.job_queue.run_once(self.send_batch_messages, seconds, context=user_notification_context,
                                       name=f'Sending: {message[0:10]}')
 
         return True

--- a/bot/messages.py
+++ b/bot/messages.py
@@ -62,40 +62,37 @@ class TelegramNotification:
         for user in chats_list:
             user_message_context = SendUserMessageContext(message=message, telegram_id=user.telegram_id)
             user_notification_context.user_message_context.append(user_message_context)
-            send_time = datetime.datetime.now(pytz.utc)
-        send_time = self.send_batch_messages(user_notification_context, send_time)
+
+        dispatcher.job_queue.run_once(self.send_batch_messages, 1, context=user_notification_context,
+                                      name=f'Sending: {message[0:10]}')
 
         return True
 
-    def send_batch_messages(self, user_notification_context, send_time):
-        for send_set in self.__split_chats(user_notification_context.user_message_context, config.MAILING_BATCH_SIZE):
+    def send_batch_messages(self, user_notification_context):
+        job = user_notification_context.job
+        user_message_context = job.context.user_message_context
+        for send_set in self.__split_chats(user_message_context, config.MAILING_BATCH_SIZE):
 
             for user_message_context in send_set:
-                dispatcher.job_queue.run_once(self.__send_message_context, send_time, context=user_message_context,
-                                              name=f'Sending: {user_message_context.message[0:10]}')
-                send_time = send_time + datetime.timedelta(seconds=1)
-                # self.__send_message_context(user_message_context)
-        return send_time
+                self.__send_message_context(user_message_context)
+            time.sleep(1)
                 
     def __send_message_context(self, user_message_context):
-        job = user_message_context.job
-        message = job.context.message
-        telegram_id = job.context.telegram_id
         tries = 3
         for i in range(tries):
             try:
-                bot.send_message(chat_id=telegram_id, text=message,
+                bot.send_message(chat_id=user_message_context.telegram_id, text=user_message_context.message,
                                 parse_mode=ParseMode.HTML, disable_web_page_preview=True)
-                logger.info(f"Sent message to {telegram_id}")
+                logger.info(f"Sent message to {user_message_context.telegram_id}")
                 return
             except error.BadRequest as ex:
-                logger.error(f'{str(ex.message)}, telegram_id: {telegram_id}')
+                logger.error(f'{str(ex.message)}, telegram_id: {user_message_context.telegram_id}')
                 if i < tries:
                     logger.info(f"Retry to send after {i}")
                     time.sleep(i)
             except Unauthorized as ex:
-                logger.error(f'{str(ex.message)}: {telegram_id}')
-                User.query.filter_by(telegram_id=telegram_id).update({'banned': True, 'has_mailing': False})
+                logger.error(f'{str(ex.message)}: {user_message_context.telegram_id}')
+                User.query.filter_by(telegram_id=user_message_context.telegram_id).update({'banned': True, 'has_mailing': False})
                 db_session.commit()
 
     @staticmethod

--- a/bot/messages.py
+++ b/bot/messages.py
@@ -54,14 +54,13 @@ class TelegramNotification:
         return True
 
     def send_new_tasks(self, message, send_to, send_time):
-        
-        for i, part in enumerate(self.__split_chats(send_to, config.MAILING_BATCH_SIZE)):
-            context = {'message': message, 'chats': part}
+        for chats_count, chats_set in enumerate(self.__split_chats(send_to, config.MAILING_BATCH_SIZE)):
+            context = {'message': message, 'chats': chats_set}
 
-            send_time = send_time + datetime.timedelta(seconds=i)
+            send_time = send_time + datetime.timedelta(seconds=chats_count)
 
             dispatcher.job_queue.run_once(self.__send_message, send_time, context=context,
-                                          name=f'Task: {message[0:10]}_{i}')
+                                          name=f'Task: {message[0:10]}_{chats_count}')
             
         return send_time
 


### PR DESCRIPTION
Переименовал метод send_task в preparing_tasks_for_send.

Переименовал константу NUMBER_USERS_TO_SEND в MAILING_BATCH_SIZE.

Поменял логику отправки сообщений в чаты Телеграм. Для этого  в preparing_tasks_for_send при подготовки сообщений объявил переменную send_time и задал ее текущим временем в местном часовом поясе. При отправке каждого сообщения прибавлял к ней по 1 секунде и передавал в send_new_tasks.
Там к ней добавил значения счетчик чатов и снова вернул ее в preparing_tasks_for_send.
Это позволило добиться отправки каждого сообщения раз в секунду в n чатов (MAILING_BATCH_SIZE) и избавиться от ошибок типа:
`2022-10-20 15:22:53,285	WARNING	connectionpool.py:275	Connection pool is full, discarding connection: api.telegram.org`