### PR TITLE
'Changing the timezone in the logs to Minsk. time'

### DIFF
--- a/app/logger.py
+++ b/app/logger.py
@@ -1,10 +1,17 @@
 import logging
 import os
+from datetime import datetime
 from logging.handlers import TimedRotatingFileHandler
+
+import pytz
+
 from app import config
 
+utcmoment_naive = datetime.utcnow()
+utcmoment = utcmoment_naive.replace(tzinfo=pytz.utc)
+MINSK_TIME = utcmoment.astimezone(pytz.timezone('Europe/Minsk')).strftime('%Y-%m-%d %H:%M:%S.%f')[:-3]
 
-FORMATTER = u'%(asctime)s\t%(levelname)s\t%(filename)s:%(lineno)d\t%(message)s'
+FORMATTER = f'{MINSK_TIME}\t%(levelname)s\t%(filename)s:%(lineno)d\t%(message)s'
 
 
 def create_log_directory(directory):


### PR DESCRIPTION
в app/logger.py изменил константу FORMATTER для вывода времени привязанной к TZ Минск, то есть + 3 часа. Формат вывода времени остался прежний, до 3 миллисекунд (Пример: 2022-12-08 18:19:16.929). Для TZ пришлось добавить модуль pytz. Можно было изменить в одну строчку, привязываясь к времени на сервере, но в случае изменения времени на сервере, с TZ более надежно. Если в Белоруссии снова введут зимнее время, то надо будет внести сюда правки.       